### PR TITLE
Release 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 1.0.0 - 2025-05-01
+## [1.0.1] - 2025-05-05
+
+### Fixed
+- fix: Make hook use namespaces by @GaryJones in https://github.com/Automattic/BuddyPress-Profile-Type-Assigner/pull/2
+
+## 1.0.0 - 2025-04-30
 
 Initial release of BuddyPress Profile Type Assigner.
+
+[1.0.1]: https://github.com/automattic/buddypress-profile-type-assigner/compare/1.0.0...1.0.1

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 **Tags:** BuddyPress, BuddyBoss, profile types, roles  
 **Requires at least:** 6.6  
 **Tested up to:** 6.8  
-**Stable tag:** 1.0.0  
+**Stable tag:** 1.0.1  
 **License:** GPLv2 or later  
 **License URI:** https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/buddypress-profile-type-assigner.php
+++ b/buddypress-profile-type-assigner.php
@@ -40,17 +40,17 @@ define(
 */
 
 // Hook into user activation.
-add_action( 'bp_core_activated_user', 'buddypress_profile_type_assigner', 1000 );
+add_action( 'bp_core_activated_user', __NAMESPACE__ . '\\assign_profile_type', 1000 );
 
 // Add a hook to run after activation is complete - without this, the pending user becomes a Subscriber again.
-add_action( 'bp_after_activation', 'buddypress_profile_type_assigner', 1000 );
+add_action( 'bp_after_activation', __NAMESPACE__ . '\\assign_profile_type', 1000 );
 
 /**
  * Assigns profile type based on email domain.
  *
  * @param int $user_id The user ID.
  */
-function buddypress_profile_type_assigner( $user_id ) {
+function assign_profile_type( $user_id ) {
 	
 	// Get user data.
 	$user = get_userdata( $user_id );

--- a/buddypress-profile-type-assigner.php
+++ b/buddypress-profile-type-assigner.php
@@ -10,7 +10,7 @@
  * @wordpress-plugin
  * Plugin Name:       BuddyPress Profile Type Assigner
  * Description:       Automatically assigns BuddyPress profile types to new users based on their email domain.
- * Version:           1.0.0
+ * Version:           1.0.1
  * Requires at least: 6.6
  * Requires PHP:      8.2
  * Author:            WordPress VIP


### PR DESCRIPTION
### Fixed
- fix: Make hook use namespaces by @GaryJones in https://github.com/Automattic/BuddyPress-Profile-Type-Assigner/pull/2